### PR TITLE
feat: display room id, room creator

### DIFF
--- a/src/routes/(auth)/_auth.lobby.tsx
+++ b/src/routes/(auth)/_auth.lobby.tsx
@@ -30,7 +30,7 @@ function LobbyPage() {
         name: room.name,
         players: room.players,
         status: formatRoomStatus(room.status),
-        creator: room.creator.username,
+        creator: room.creator,
       }));
 
       setGameRooms(rooms);
@@ -55,7 +55,7 @@ function LobbyPage() {
               name: room.name,
               players: room.players,
               status: formatRoomStatus(room.status),
-              creator: room.creator.username,
+              creator: room.creator,
             }));
 
             setGameRooms(rooms);
@@ -186,8 +186,14 @@ function LobbyPage() {
                         {room.status}
                       </span>
                     </div>
-                    <div className="mt-2 text-sm text-gray-500">
-                      Players: {room.players.length}/2
+                    <div className="mt-2 grid grid-cols-2 text-sm text-gray-500">
+                      <div>Players: {room.players.length}/2</div>
+                      <div className="text-right">
+                        Created by: {room.creator.username}
+                      </div>
+                      <div className="text-xs mt-1 text-gray-400">
+                        ID: {room.id}
+                      </div>
                     </div>
                     <div className="mt-2">
                       <Button


### PR DESCRIPTION

This pull request updates the `LobbyPage` component in `src/routes/(auth)/_auth.lobby.tsx` to enhance the display of room details and simplify the handling of the `creator` field. The most important changes include restructuring the `creator` property, improving the layout of room information, and adding new details to the UI.

### Changes to data handling:
* Updated the `creator` property in the `rooms` mapping to store the entire `room.creator` object instead of just `room.creator.username`. This change was applied in two places to ensure consistency. [[1]](diffhunk://#diff-98b737590655bac3503160f58a7e7658dfebf15ffbc5634d65ff4d4a3a0748a4L33-R33) [[2]](diffhunk://#diff-98b737590655bac3503160f58a7e7658dfebf15ffbc5634d65ff4d4a3a0748a4L58-R58)

### UI improvements:
* Enhanced the room details section by converting the player count and creator information into a two-column grid layout. Added a new line to display the room ID in smaller text for better visibility.